### PR TITLE
Minor translation fix

### DIFF
--- a/GPLv3-spanish.txt
+++ b/GPLv3-spanish.txt
@@ -529,19 +529,19 @@ Términos y Condiciones
       aplicarán a la combinación como tal.
   15. Versiones Revisadas de esta Licencia.
       La Free Software Foundation puede publicar versiones revisadas y/o nuevas
-      de la Licencia General Pública de GNU de vez en cuando. Cada nueva
+      de la Licencia Pública General de GNU de vez en cuando. Cada nueva
       versión será similar en espíritu a la versión actual, pero puede diferir
       en detalles para abordar nuevos problemas o preocupaciones.
       Cada versión recibe un número de versión distintivo. Si el Programa
-      especifica que cierta versión numerada de la Licencia General Pública de
+      especifica que cierta versión numerada de la Licencia Pública General de
       GNU “o cualquier versión posterior” se aplica a él, usted tiene la opción
       de seguir los términos y condiciones de esa versión numerada o de
       cualquier versión posterior publicada por la Free Software Foundation. Si
-      el Programa no especifica un número de versión de la Licencia General
-      Pública de GNU, usted puede escoger cualquier versión publicada por la
+      el Programa no especifica un número de versión de la Licencia Pública
+      General de GNU, usted puede escoger cualquier versión publicada por la
       Free Software Foundation.
       Si el Programa escifica que un representante puede decidir que versiones
-      futuras de la Licencia General Pública de GNU pueden ser utilizadas, la
+      futuras de la Licencia Pública General de GNU pueden ser utilizadas, la
       declaración pública del representante de aceptar una versión
       permanentemente le autoriza a usted a elegir esa versión para el
       Programa.
@@ -596,16 +596,16 @@ Términos y Condiciones
       Copyright (C) <año>  <nombre del autor>
 
       Este programa es software libre: puede redistribuirlo y/o modificarlo
-      bajo los términos de la Licencia General Pública de GNU publicada por la 
+      bajo los términos de la Licencia Pública General de GNU publicada por la 
       Free Software Foundation, ya sea la versión 3 de la Licencia, o (a su
       elección) cualquier versión posterior.
 
       Este programa se distribuye con la esperanza de que sea útil pero SIN
       NINGUNA GARANTÍA; incluso sin la garantía implícita de MERCANTIBILIDAD o
-      CALIFICADA PARA UN PROPÓSITO EN PARTICULAR. Vea la Licencia General
-      Pública de GNU para más detalles.
+      CALIFICADA PARA UN PROPÓSITO EN PARTICULAR. Vea la Licencia Pública
+      General de GNU para más detalles.
 
-      Usted ha debido de recibir una copia de la Licencia General Pública
+      Usted ha debido de recibir una copia de la Licencia Pública General
       de GNU junto con este programa. Si no, vea <http://www.gnu.org/licenses/>.
 
       También añada información sobre cómo contactarle por correo electrónico u
@@ -618,7 +618,7 @@ Términos y Condiciones
       redistribuirlo bajo ciertas condiciones; escriba `show c' para más
       información.
       Los hipotéticos comandos show w y show w deberán mostrar las partes
-      correspondientes de la Licencia General Pública. Por supuesto, los
+      correspondientes de la Licencia Pública General. Por supuesto, los
       comandos en su programa pueden ser diferentes; para una interfaz gráfica
       de usuario, puede usar un mensaje del tipo “Acerca de”.
       También debería conseguir que su empresa (si trabaja como programador) o
@@ -626,7 +626,7 @@ Términos y Condiciones
       (“copyright”)” sobre el programa, si fuese necesario. Para más
       información a este respecto, y saber cómo aplicar y cumplir la licencia
       GNU GPL, consulte http://www.gnu.org/licenses/.
-      La Licencia General Pública de GNU no permite incorporar sus programas
+      La Licencia Pública General de GNU no permite incorporar sus programas
       como parte de programas propietarios. Si su programa es una subrutina en
       una biblioteca, podría considerar mucho más útil permitir el enlace de
       aplicaciones propietarias con la biblioteca. Si esto es lo que quiere


### PR DESCRIPTION
The translation should read “Licencia Pública General” not “Licencia General Pública.” This fix will also makes it consistent with the main title.